### PR TITLE
Bugfix - Config classes injected in Topology model break clean install

### DIFF
--- a/Model/Topology.php
+++ b/Model/Topology.php
@@ -7,10 +7,10 @@
 
 namespace Belvg\Sqs\Model;
 
-use Belvg\Sqs\Helper\Data;
-use Magento\Framework\Communication\ConfigInterface as CommunicationConfig;
-use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Communication\ConfigInterface\Proxy as CommunicationConfig;
 use Magento\Framework\MessageQueue\ConfigInterface\Proxy as QueueConfig;
+use Magento\Framework\Exception\LocalizedException;
+use Belvg\Sqs\Helper\Data;
 
 /**
  * Class Topology creates topology for Amqp messaging


### PR DESCRIPTION
Injecting them as proxies fix the issue